### PR TITLE
Minor improvement to the FileDownloader class.

### DIFF
--- a/FileDownloader.m
+++ b/FileDownloader.m
@@ -139,10 +139,14 @@
 {
     [data appendData:inData];
     
-    float downloadedLenght = data.length;
-    float downloadProgress = downloadedLenght / self.expectedContentLenght;
-	
-	[self.delegate downloader:self downloadProgressWasUpdatedTo:downloadProgress];
+    if([delegate respondsToSelector:@selector(downloader:downloadProgressWasUpdatedTo:)] &&
+       self.expectedContentLenght != NSURLResponseUnknownLength)
+    {
+        float downloadedLenght = data.length;
+        float downloadProgress = downloadedLenght / self.expectedContentLenght;
+        
+        [self.delegate downloader:self downloadProgressWasUpdatedTo:downloadProgress];
+    }
 }
 
 @end


### PR DESCRIPTION
Made the FileDownloader report progress to the delegate only if it responds to the downloader:downloadProgressWasUpdatedTo: method, since it's optional, and if the expected lenght is known, since not all servers support this feature.

Before this change, if FileDownloder's delegate didn't implement the downloader:downloadProgressWasUpdatedTo: it would crash. I'm sorry I introduced the bug. I'm used to having my delegates' methods mostly required.
