### PR TITLE
Remove dismiss view controller

### DIFF
--- a/HelpViewController.m
+++ b/HelpViewController.m
@@ -41,11 +41,7 @@
 
 -(IBAction)doneTouched:(id)sender;
 {
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0
-    [self dismissViewControllerAnimated:YES completion:nil];
-#else
-    [self dismissModalViewControllerAnimated:YES];
-#endif
+
     [self.delegate viewControllerFinishedModalAction:self];
 }
 


### PR DESCRIPTION
In the doneTouched: method the dismiss view controller block is removed. This is unnecessary as the code after that assumes that a delegate will be assigned and the delegate will dismiss the Help View Controller. The delegate should be responsible in calling [self.slideController dismissViewControllerAnimated:YES completion:nil];
